### PR TITLE
Fix parsing package.json

### DIFF
--- a/src/utils/get-dependencies-reg-exps.ts
+++ b/src/utils/get-dependencies-reg-exps.ts
@@ -32,8 +32,8 @@ function readDependenciesFromPackageJson() {
   try {
     const parsedPackageJson = JSON.parse(packageJsonContents);
 
-    const dependencies = Object.keys(parsedPackageJson.dependencies);
-    const devDependencies = Object.keys(parsedPackageJson.devDependencies);
+    const dependencies = Object.keys(parsedPackageJson.dependencies || []);
+    const devDependencies = Object.keys(parsedPackageJson.devDependencies || []);
 
     return [...dependencies, ...devDependencies];
   } catch (error) {


### PR DESCRIPTION
When `devDependencies` or `dependencies` do not exist.